### PR TITLE
fix: hardmode reducing regen multiplier by 40%

### DIFF
--- a/ConfigurableDifficultyPlugin.cs
+++ b/ConfigurableDifficultyPlugin.cs
@@ -264,6 +264,7 @@ namespace ConfigurableDifficulty
                             args.healthMultAdd += playerMaxHealth.Value / 100f;
                             args.baseShieldAdd += sender.maxHealth * playerMaxShield.Value / 100f;
                             args.regenMultAdd += playerRegen.Value / 100f;
+                            if (configurableDifficultyDef.countsAsHardMode) args.regenMultAdd += 0.4f;
                             args.baseRegenAdd += playerBaseRegen.Value;
                             if (playerSpeed.Value > 0f) args.moveSpeedMultAdd += playerSpeed.Value / 100f;
                             else args.moveSpeedReductionMultAdd -= playerSpeed.Value / 100f;

--- a/ConfigurableDifficultyPlugin.cs
+++ b/ConfigurableDifficultyPlugin.cs
@@ -264,7 +264,7 @@ namespace ConfigurableDifficulty
                             args.healthMultAdd += playerMaxHealth.Value / 100f;
                             args.baseShieldAdd += sender.maxHealth * playerMaxShield.Value / 100f;
                             args.regenMultAdd += playerRegen.Value / 100f;
-                            if (configurableDifficultyDef.countsAsHardMode) args.regenMultAdd += 0.4f;
+                            if (countsAsHardMode.Value) args.regenMultAdd += 0.4f;
                             args.baseRegenAdd += playerBaseRegen.Value;
                             if (playerSpeed.Value > 0f) args.moveSpeedMultAdd += playerSpeed.Value / 100f;
                             else args.moveSpeedReductionMultAdd -= playerSpeed.Value / 100f;


### PR DESCRIPTION
A bug I noticed, is that when `countsAsHardMode` is set to true, player regen multiplier is reduced by 0.4, as though it's already applying Monsoon regen penalty.

For example: 

- Setting player regen multiplier to 0% should give 100% regen, when in reality it gives 60%. 
- Setting it to -40% should give 60%, when in reality it gives 20%
- Setting it to -100% should give 0%, when in reality it gives -40% (negative regen).

As far as I can tell, this does not apply to allies or enemies, just players. It also only occurs with `countsAsHardMode = true`. When it is false, the game uses regular Rainstorm values for regen.

If I had to guess, this is an issue with R2API? There's nothing incriminating in the code, as far as I can tell. My theory is that R2API or the game, notices that mastery camos are unlockable, and assumes the current difficulty setting is Monsoon, and bases player regen calculations off of that. I'm completely uncertain though.

What this PR does is check if hardmode is active, and if it is increases `args.regenMultAdd` by 0.4f. It solves the symptom, not the issue, but afaik it works.

**DISCLAIMER: I HAVE NOT TESTED THIS IN THE SLIGHTEST! I DON'T MOD ROR2, AND I DON'T KNOW HOW TO COMPILE A MOD FOR IT. I DO NOT KNOW IF THIS CHANGE WILL BREAK EVERYTHING OR NOT. FURTHER TESTING IS REQUIRED!**